### PR TITLE
URL of API rest resource without double slash

### DIFF
--- a/is_core/patterns.py
+++ b/is_core/patterns.py
@@ -123,7 +123,7 @@ class RestPattern(ViewPattern):
     def get_url_prefix(self):
         url_prefix = super(RestPattern, self).get_url_prefix()
         if url_prefix:
-            return  'api/%s/' % url_prefix
+            return 'api/%s' % url_prefix
 
     def get_view(self):
         if self.resource.login_required:


### PR DESCRIPTION
URL na zdroj byla např. /api/eshop//3/ - dvě lomítka mezi názvem zdroje a id.
