### PR TITLE
Override __unicode__ in SaveObjectException

### DIFF
--- a/is_core/generic_views/exceptions.py
+++ b/is_core/generic_views/exceptions.py
@@ -1,4 +1,6 @@
 
 
 class SaveObjectException(Exception):
-    pass
+    
+    def __unicode__(self):
+        return self.message


### PR DESCRIPTION
In case of an exception e.g. in save method of the model, the exception is propagated correctly to the form but the user is presented with a generic error message "Please, correct the errors below". Caused by not overriding the **unicode** method in the SaveObjectException.

It might cause showing unwanted error messages in flexibee_backend (see save_model method in flexibee_backend/is_core/init) which may be easily fixed there.
