### PR TITLE
Bugfix: Empty filter was not shown if choice value was equal to 0

### DIFF
--- a/is_core/filters/default_filters.py
+++ b/is_core/filters/default_filters.py
@@ -108,7 +108,7 @@ class DefaultFieldFilter(DefaultFilter):
         if formfield:
             if hasattr(formfield, 'empty_label'):
                 formfield.empty_label = self.get_placeholder() or self.EMPTY_LABEL
-            elif hasattr(formfield, 'choices') and formfield.choices and formfield.choices[0][0]:
+            elif hasattr(formfield, 'choices') and formfield.choices and not formfield.choices[0][0] == '':
                 formfield.choices.insert(0, ('', self.get_placeholder() or self.EMPTY_LABEL))
             return formfield.widget
         return forms.TextInput()


### PR DESCRIPTION
The last term of the condition statement was probably meant to check if there is not an empty filter choice already among the choices but failed to add the empty filter if the value of the first select was 0 or anything else that evaluates to False other than empty string.
