### PR TITLE
New model decimal field with the 'step' attribute

### DIFF
--- a/is_core/forms/fields.py
+++ b/is_core/forms/fields.py
@@ -1,0 +1,14 @@
+from django.forms import DecimalField as OriginDecimalField
+
+
+class DecimalField(OriginDecimalField):
+
+    def __init__(self, *args, **kwargs):
+        self.step = kwargs.pop('step', 'any')
+        super(DecimalField, self).__init__(*args, **kwargs)
+
+    def widget_attrs(self, widget):
+        attrs = super(DecimalField, self).widget_attrs(widget)
+        attrs['step'] = self.step
+        return attrs
+


### PR DESCRIPTION
Allows for the 'step' attribute in the resulting HTML input element to be set on the model. Defaults to 'any' which is much more convenient than Django's 0.01. 'Any' allows for arbitrary float values and the step performed by the widget is 1. 

Any other value means the number in the input element must correspond to the step. Browser performs validation and forbids sending e.g. input with value 2.1 and step=1 cannot be sent.
