### PR TITLE
Fix DateFilter - parsing date

### DIFF
--- a/is_core/filters/default_filters.py
+++ b/is_core/filters/default_filters.py
@@ -205,7 +205,7 @@ class DateFilter(DefaultFieldFilter):
         parse = DEFAULTPARSER._parse(self.value, dayfirst=True)
         if parse is None:
             raise ValueError()
-        res, _ = parse
+        res = parse[0] if isinstance(parse, tuple) else parse
         filter_terms = {}
 
         for attr in self.extra_suffixes:


### PR DESCRIPTION
Metoda DEFAULTPARSER._parse může kromě None a tuplu vrátit také jen samotný objekt. Dříve se počítalo s tím, že vrací tuple, což nemusí být vždy pravda.

Nevím proč, ale teď mi to vždy vrací samotný objekt. Proto také nefunguje filtrování podle data v gridu - na produkci i u mě.
