### PR TITLE
Fixed css class as list in inline views

### DIFF
--- a/is_core/generic_views/inlines/inline_objects_views.py
+++ b/is_core/generic_views/inlines/inline_objects_views.py
@@ -51,7 +51,7 @@ class InlineObjectsView(InlineView):
         context_data.update({
             'data_list': self.get_data_list(self.get_fields(), self.get_objects()),
             'header_list': self.get_header_list(self.get_fields()),
-            'class_names': [self.get_class_names()],
+            'class_names': self.get_class_names(),
             })
         return context_data
 


### PR DESCRIPTION
This fixed issue when list came as a item to class_names list and then this was printed in css classes as ['view.__name__']