### PR TITLE
Added js-grid css class to grid table

### DIFF
--- a/is_core/templates/generic_views/table.html
+++ b/is_core/templates/generic_views/table.html
@@ -49,7 +49,7 @@
 						</div>
 					{% endif %}
 				{% endblock %}
-				<table class="{% block table-classes %}grid table table-striped{% endblock %}" data-resource="{{ api_url }}{% if query_string_filter %}?{{ query_string_filter }}{% endif %}" data-model="{{ module_name|capfirst }}" data-cols="{{ list_display|join:',' }}" data-rest-fields="{{ rest_fieldset }}" data-confirm="{% trans 'Do you really want to delete &#37;s?' %}" data-btn-yes="{% trans 'Yes' %}" data-btn-no="{% trans 'No' %}" data-context="{{ menu_group_pattern_name }}" data-confirm-title="{% trans 'Are you sure?' %}" {% block table-attributes %}{% endblock %}>
+				<table class="{% block table-classes %}grid js-grid table table-striped{% endblock %}" data-resource="{{ api_url }}{% if query_string_filter %}?{{ query_string_filter }}{% endif %}" data-model="{{ module_name|capfirst }}" data-cols="{{ list_display|join:',' }}" data-rest-fields="{{ rest_fieldset }}" data-confirm="{% trans 'Do you really want to delete &#37;s?' %}" data-btn-yes="{% trans 'Yes' %}" data-btn-no="{% trans 'No' %}" data-context="{{ menu_group_pattern_name }}" data-confirm-title="{% trans 'Are you sure?' %}" {% block table-attributes %}{% endblock %}>
 					<thead>
 						{% block table-header %}
 							<tr>


### PR DESCRIPTION
We needed to decouple appearance of grid and javascript functionality, so we changed selector that binds javascript to table grid to js-grid and now we need it in is-core too to make grid work.