### PR TITLE
Filters can have more than one prefix

### DIFF
--- a/is_core/filters/__init__.py
+++ b/is_core/filters/__init__.py
@@ -27,7 +27,7 @@ def get_model_field_or_method_filter(full_field_term, model, value=None, filter_
 
     if (field_or_method and next_filter_term and next_filter_term not in field_or_method.filter.get_suffixes() and
             isinstance(field_or_method, RelatedField)):
-        return get_model_field_or_method_filter(filter_term, model._meta.get_field(current_filter_term).rel.to,
+        return get_model_field_or_method_filter(full_field_term, model._meta.get_field(current_filter_term).rel.to,
                                                 value, next_filter_term, ui=ui)
     elif ui and hasattr(field_or_method, 'filter_by'):
         return get_model_field_or_method_filter(


### PR DESCRIPTION
Filters havn't reveiced full filter term. Just last one, so filters with more than 2 prefixes haven't worked.