### PR TITLE
Fixed SelectMixin to work with Django 1.9

### DIFF
--- a/is_core/forms/widgets.py
+++ b/is_core/forms/widgets.py
@@ -83,7 +83,7 @@ class SelectMixin(object):
                            flat_data_attrs(option_attrs) or '',
                            force_text(option_label))
 
-    def render_options(self, selected_choices):
+    def render_options(self, selected_choices, value=None):  # value argument is here to ensure Django 1.9 compatibility
         # Normalize to strings.
         selected_choices = set(force_text(v) for v in selected_choices)
         output = []


### PR DESCRIPTION
render_options method is called with an extra argument in 1.9