### PR TITLE
Flag bulk change form

### DIFF
--- a/is_core/forms/models.py
+++ b/is_core/forms/models.py
@@ -233,7 +233,7 @@ def get_model_fields(model, fields):
 def smartmodelform_factory(model, request, form=SmartModelForm, fields=None, readonly_fields=None, exclude=None,
                            formfield_callback=None, widgets=None, localized_fields=None, required_fields=None,
                            labels=None, help_texts=None, error_messages=None, formreadonlyfield_callback=None,
-                           readonly=False, fields_to_clean=None):
+                           readonly=False, fields_to_clean=None, is_bulk=False):
     attrs = {'model': model}
     if fields is not None:
         model_fields = get_model_fields(model, fields)
@@ -259,6 +259,7 @@ def smartmodelform_factory(model, request, form=SmartModelForm, fields=None, rea
     if fields_to_clean is not None:
         attrs['fields_to_clean'] = fields_to_clean
     attrs['readonly'] = readonly
+    attrs['is_bulk'] = is_bulk
     # If parent form class already has an inner Meta, the Meta we're
     # creating needs to inherit from the parent's inner meta.
     parent = (object,)

--- a/is_core/generic_views/form_views.py
+++ b/is_core/generic_views/form_views.py
@@ -353,6 +353,9 @@ class DefaultModelFormView(DefaultFormView):
     def get_form_class_base(self):
         return self.form_class or SmartModelForm
 
+    def get_is_bulk(self):
+        return False
+
     def generate_form_class(self, fields=None, readonly_fields=()):
         form_class = self.get_form_class_base()
         exclude = list(self.get_exclude())
@@ -363,7 +366,7 @@ class DefaultModelFormView(DefaultFormView):
                                       readonly_fields=readonly_fields,
                                       formreadonlyfield_callback=self.formfield_for_readonlyfield,
                                       readonly=not self.has_post_permission(),
-                                      labels=self._get_field_labels())
+                                      labels=self._get_field_labels(), is_bulk=self.get_is_bulk())
 
     def update_form_initial(self, form):
         # Only new instance can get data from request queryset
@@ -688,3 +691,6 @@ class BulkChangeFormView(DefaultModelFormView):
 
     def get_readonly_fields(self):
         return ()
+
+    def get_is_bulk(self):
+        return True


### PR DESCRIPTION
Sometimes it is good to know if form is intended for bulk change (e.g. when rendering widgets). This PR solves this problem by adding `is_bulk` flag to form's `Meta` inside form factory. 