### PR TITLE
Make bulk change fields dynamic

### DIFF
--- a/is_core/generic_views/form_views.py
+++ b/is_core/generic_views/form_views.py
@@ -678,10 +678,7 @@ class BulkChangeFormView(DefaultModelFormView):
         return super(BulkChangeFormView, self).dispatch(request, *args, **kwargs)
 
     def get_fields(self):
-        return (
-            (self.core.bulk_change_fields if hasattr(self.core, 'bulk_change_fields') else ())
-            if self.fields is None else self.fields
-        )
+        return self.core.get_bulk_change_fields(self.request) if self.fields is None else self.fields
 
     def get_fieldsets(self):
         return (

--- a/is_core/main.py
+++ b/is_core/main.py
@@ -401,6 +401,9 @@ class UIModelISCore(ModelISCore, UIISCore):
     def get_bulk_change_url_name(self):
         return self.bulk_change_url_name
 
+    def get_bulk_change_fields(self, request):
+        return getattr(self, 'bulk_change_fields', ())
+
     def get_urls(self):
         return self.get_urlpatterns(self.ui_patterns)
 


### PR DESCRIPTION
It is better to have a method that returns `bulk_change_fields`, because it can be overriden, i.e. dynamically change which fields will be shown in the bulk change form.