### PR TITLE
Accept W3C token format

### DIFF
--- a/is_core/config.py
+++ b/is_core/config.py
@@ -8,6 +8,7 @@ DEFAULTS = {
     'AUTH_COOKIE_SECURE': False,
     'AUTH_COOKIE_DOMAIN': None,
     'AUTH_HEADER_NAME': 'Authorization',
+    'AUTH_HEADER_TOKEN_TYPE': 'Bearer',
     'AUTH_DEFAULT_TOKEN_AGE': 60 * 60,  # Default token expiration time (default: 1 hour)
     'AUTH_MAX_TOKEN_AGE': 60 * 60 * 24 * 7 * 2,  # Max token expiration time (default: 2 weeks)
     'AUTH_COUNT_USER_PRESERVED_TOKENS': 20,

--- a/is_core/tests/auth_test_cases.py
+++ b/is_core/tests/auth_test_cases.py
@@ -2,6 +2,7 @@ from germanium.tools.rest import assert_valid_JSON_response
 
 from is_core.config import settings
 from is_core.utils import header_name_to_django
+from is_core.auth_token.utils import create_auth_header_value
 
 
 class RESTAuthMixin:
@@ -12,7 +13,7 @@ class RESTAuthMixin:
                              data={settings.USERNAME: username, settings.PASSWORD: password})
             assert_valid_JSON_response(resp, 'REST authorization fail: %s' % resp)
             self.default_headers[header_name_to_django(settings.AUTH_HEADER_NAME)] = (
-                self.deserialize(resp).get('token')
+                create_auth_header_value(self.deserialize(resp).get('token'))
             )
         else:
             super(RESTAuthMixin, self).authorize(username, password)


### PR DESCRIPTION
Restrict accepted format of the `Authorization` HTTP header value to a format described by W3C, i.e. the value must be in form:
```
Authorization: Bearer <token>
```