### PR TITLE
instalation fixes

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ Python/Django versions
 Libraries
 ^^^^^^^^^
 
- * **django-class-based-auth-views** - Login/Logkout views as generic view structure
+ * **django-class-based-auth-views** - Login/Logout views as generic view structure
  * **django-piston** - not original pistion library, but improved. You can find it here https://github.com/matllubos/django-piston
  * **django-block-snippets** - library providing block snippets of html code for easier development webpages with ajax. You can find it here https://github.com/matllubos/django-block-snippets
  * **django-chamber** - several helpers removing code duplication. You can find it here https://github.com/matllubos/django-chamber
@@ -82,7 +82,7 @@ Next add two middlewares to end of ``MIDDLEWARE_CLASSES`` variable::
     MIDDLEWARE_CLASSES = (
         ...
         'is_core.middleware.RequestKwargsMiddleware',
-        'is_core.middleware.HttpExceptionsMiddleware',
+        'is_core.middleware.HTTPExceptionsMiddleware',
     )
 
 Setup


### PR DESCRIPTION
I encountered a few issues during fresh installation
```
Traceback (most recent call last):
  File ".../venv/lib64/python3.6/site-packages/django/utils/module_loading.py", line 20, in import_string
    return getattr(module, class_name)
AttributeError: module 'is_core.middleware' has no attribute 'HttpExceptionsMiddleware'
```
```
File ".../venv/lib64/python3.6/site-packages/django/template/backends/django.py", line 125, in get_package_libraries
    "trying to load '%s': %s" % (entry[1], e)
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'is_core.templatetags.menu': cannot import name 'OffsetBasedPaginator'
```