### PR TITLE
fix exported file download permissions

### DIFF
--- a/is_core/contrib/background_export/views.py
+++ b/is_core/contrib/background_export/views.py
@@ -21,7 +21,7 @@ class DownloadExportedDataView(RedirectView):
 
         if (core.permission.has_permission('read_all', self.request, self, obj=exported_file)
                 or (core.permission.has_permission('read_own', self.request, self, obj=exported_file)
-                    and exported_file.created_by == self.request.user)):
+                    and exported_file.created_by.pk == self.request.user.pk)):
             exported_file.downloaded_by.add(self.request.user)
             return exported_file.file.url
         else:


### PR DESCRIPTION
Since the models can be different (one of them is SimpleLazyObject) `==` comparison (equaling to calling `__eq__`) does not work properly. `pk` comparison also works, but this should be more generic.